### PR TITLE
Substitute RHSM skip variable

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/authselectapply/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectapply/actor.py
@@ -3,7 +3,7 @@ from leapp.libraries.stdlib import run, CalledProcessError
 from leapp.models import Authselect, AuthselectDecision
 from leapp import reporting
 from leapp.reporting import Report, create_report
-from leapp.tags import IPUWorkflowTag, ApplicationsPhaseTag
+from leapp.tags import IPUWorkflowTag, ApplicationsPhaseTag, ExperimentalTag
 
 
 resources = [
@@ -24,7 +24,7 @@ class AuthselectApply(Actor):
     name = 'authselect_apply'
     consumes = (Authselect, AuthselectDecision,)
     produces = (Report,)
-    tags = (IPUWorkflowTag, ApplicationsPhaseTag)
+    tags = (IPUWorkflowTag, ApplicationsPhaseTag, ExperimentalTag)
 
     def process(self):
         model = next(self.consume(Authselect))

--- a/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectcheck/actor.py
@@ -4,7 +4,7 @@ from leapp.dialogs.components import BooleanComponent
 from leapp.models import Authselect, AuthselectDecision
 from leapp.reporting import Report, create_report
 from leapp import reporting
-from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag
 
 
 resources = [
@@ -26,7 +26,7 @@ class AuthselectCheck(Actor):
     name = 'authselect_check'
     consumes = (Authselect,)
     produces = (AuthselectDecision, Report,)
-    tags = (IPUWorkflowTag, ChecksPhaseTag)
+    tags = (IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag)
     dialogs = (
         Dialog(
             scope='authselect_check',

--- a/repos/system_upgrade/el7toel8/actors/authselectscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/authselectscanner/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import AuthselectScannerLibrary, Authconfig, DConf, read_file
 from leapp.libraries.common.pam import PAM
 from leapp.models import Authselect
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag, ExperimentalTag
 
 
 class AuthselectScanner(Actor):
@@ -43,7 +43,7 @@ class AuthselectScanner(Actor):
     name = 'authselect_scanner'
     consumes = ()
     produces = (Authselect,)
-    tags = (IPUWorkflowTag, FactsPhaseTag)
+    tags = (IPUWorkflowTag, FactsPhaseTag, ExperimentalTag)
 
     known_modules = [
         'pam_access',

--- a/repos/system_upgrade/el7toel8/actors/checkrhsmsku/tests/test_rhsmsku.py
+++ b/repos/system_upgrade/el7toel8/actors/checkrhsmsku/tests/test_rhsmsku.py
@@ -4,7 +4,7 @@ from leapp.models import Report, RHSMInfo
 
 def test_sku_report_skipped(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
-        context.setenv('LEAPP_DEVEL_SKIP_RHSM', '1')
+        context.setenv('LEAPP_NO_RHSM', '1')
         current_actor_context.feed(RHSMInfo(attached_skus=[]))
         current_actor_context.run()
         assert not list(current_actor_context.consume(Report))
@@ -12,7 +12,7 @@ def test_sku_report_skipped(monkeypatch, current_actor_context):
 
 def test_sku_report_has_skus(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
-        context.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+        context.setenv('LEAPP_NO_RHSM', '0')
         current_actor_context.feed(RHSMInfo(attached_skus=['testing-sku']))
         current_actor_context.run()
         assert not list(current_actor_context.consume(Report))
@@ -20,7 +20,7 @@ def test_sku_report_has_skus(monkeypatch, current_actor_context):
 
 def test_sku_report_has_no_skus(monkeypatch, current_actor_context):
     with monkeypatch.context() as context:
-        context.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+        context.setenv('LEAPP_NO_RHSM', '0')
         current_actor_context.feed(RHSMInfo(attached_skus=[]))
         current_actor_context.run()
         reports = list(current_actor_context.consume(Report))

--- a/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/libraries/library.py
+++ b/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/libraries/library.py
@@ -6,7 +6,7 @@ from leapp.models import UsedTargetRepositories
 def set_rhsm_release():
     """Set the RHSM release to the target RHEL 8 minor version."""
     if rhsm.skip_rhsm():
-        api.current_logger().debug('Skipping setting the RHSM release due to the use of LEAPP_DEVEL_SKIP_RHSM.')
+        api.current_logger().debug('Skipping setting the RHSM release due to --no-rhsm or environment variables.')
         return
 
     if config.get_product_type('target') != 'ga':
@@ -29,8 +29,8 @@ def enable_rhsm_repos():
     the known repositories.
     """
     if rhsm.skip_rhsm():
-        api.current_logger().debug('Skipping enabling repositories through subscription-manager due to the use of'
-                                   ' LEAPP_DEVEL_SKIP_RHSM.')
+        api.current_logger().debug('Skipping enabling repositories through subscription-manager due to --no-rhsm'
+                                   ' or environment variables.')
         return
     try:
         run(get_submgr_cmd(get_repos_to_enable()))

--- a/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/tests/test_enablerhsmreposonrhel8.py
+++ b/repos/system_upgrade/el7toel8/actors/enablerhsmreposonrhel8/tests/test_enablerhsmreposonrhel8.py
@@ -93,7 +93,7 @@ def test_setrelease_submgr_throwing_error(monkeypatch):
 @pytest.mark.parametrize('product', ['beta', 'htb'])
 def test_setrelease_skip_rhsm(monkeypatch, product):
     commands_called, _ = not_isolated_actions()
-    monkeypatch.setenv('LEAPP_DEVEL_SKIP_RHSM', '1')
+    monkeypatch.setenv('LEAPP_NO_RHSM', '1')
     monkeypatch.setattr(config, 'get_product_type', lambda dummy: product)
     # To make this work we need to re-apply the decorator, so it respects the environment variable
     monkeypatch.setattr(rhsm, 'set_release', rhsm.with_rhsm(rhsm.set_release))
@@ -134,7 +134,7 @@ def test_running_submgr_fail(monkeypatch):
 
 
 def test_enable_repos_skip_rhsm(monkeypatch):
-    monkeypatch.setenv('LEAPP_DEVEL_SKIP_RHSM', '1')
+    monkeypatch.setenv('LEAPP_NO_RHSM', '1')
     monkeypatch.setattr(library, 'run', run_mocked())
     monkeypatch.setattr(api, 'current_logger', logger_mocked())
     library.enable_rhsm_repos()

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulesapply/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulesapply/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import comment_modules, read_file
 from leapp.libraries.common.pam import PAM
 from leapp.models import RemovedPAMModules
-from leapp.tags import IPUWorkflowTag, PreparationPhaseTag
+from leapp.tags import IPUWorkflowTag, PreparationPhaseTag, ExperimentalTag
 
 
 class RemoveOldPAMModulesApply(Actor):
@@ -14,7 +14,7 @@ class RemoveOldPAMModulesApply(Actor):
     name = 'removed_pam_modules_apply'
     consumes = (RemovedPAMModules,)
     produces = ()
-    tags = (IPUWorkflowTag, PreparationPhaseTag)
+    tags = (IPUWorkflowTag, PreparationPhaseTag, ExperimentalTag)
 
     def process(self):
         for model in self.consume(RemovedPAMModules):

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulescheck/actor.py
@@ -4,7 +4,7 @@ from leapp.dialogs.components import BooleanComponent
 from leapp.models import RemovedPAMModules
 from leapp.reporting import Report, create_report
 from leapp import reporting
-from leapp.tags import IPUWorkflowTag, ChecksPhaseTag
+from leapp.tags import IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag
 
 
 class RemoveOldPAMModulesCheck(Actor):
@@ -18,7 +18,7 @@ class RemoveOldPAMModulesCheck(Actor):
     name = 'removed_pam_modules_check'
     consumes = (RemovedPAMModules,)
     produces = (Report,)
-    tags = (IPUWorkflowTag, ChecksPhaseTag)
+    tags = (IPUWorkflowTag, ChecksPhaseTag, ExperimentalTag)
     dialogs = (
         Dialog(
             scope='remove_pam_pkcs11_module_check',

--- a/repos/system_upgrade/el7toel8/actors/removeoldpammodulesscanner/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/removeoldpammodulesscanner/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor.library import RemoveOldPAMModulesScannerLibrary
 from leapp.libraries.common.pam import PAM
 from leapp.models import RemovedPAMModules
-from leapp.tags import IPUWorkflowTag, FactsPhaseTag
+from leapp.tags import IPUWorkflowTag, FactsPhaseTag, ExperimentalTag
 
 
 class RemoveOldPAMModulesScanner(Actor):
@@ -16,7 +16,7 @@ class RemoveOldPAMModulesScanner(Actor):
     name = 'removed_pam_modules_scanner'
     consumes = ()
     produces = (RemovedPAMModules,)
-    tags = (IPUWorkflowTag, FactsPhaseTag)
+    tags = (IPUWorkflowTag, FactsPhaseTag, ExperimentalTag)
 
     def process(self):
         pam = PAM.from_system_configuration()

--- a/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
+++ b/repos/system_upgrade/el7toel8/actors/targetuserspacecreator/tests/unit_test.py
@@ -150,7 +150,7 @@ def test_consume_data(monkeypatch, raised, pkg_msgs, rhsm_info, xfs, storage):
     mocked_consume = MockedConsume(pkg_msgs, rhsm_info, xfs, storage)
     monkeypatch.setattr(api, 'consume', mocked_consume)
     monkeypatch.setattr(api, 'current_logger', mocked_logger())
-    monkeypatch.setenv('LEAPP_DEVEL_SKIP_RHSM', '0')
+    monkeypatch.setenv('LEAPP_NO_RHSM', '0')
     if not xfs:
         xfs = models.XFSPresence()
     if not raised:

--- a/repos/system_upgrade/el7toel8/libraries/mounting.py
+++ b/repos/system_upgrade/el7toel8/libraries/mounting.py
@@ -6,6 +6,9 @@ from collections import namedtuple
 from leapp.libraries.stdlib import run, CalledProcessError, api
 from leapp.libraries.common.config import get_all_envs
 
+
+ALWAYS_BIND = ['/etc/hosts:/etc/hosts']
+
 ErrorData = namedtuple('ErrorData', ['summary', 'details'])
 
 
@@ -67,7 +70,7 @@ class IsolationType(object):
 
         def __init__(self, target, binds=(), env_vars=None):
             super(IsolationType.NSPAWN, self).__init__(target=target)
-            self.binds = binds
+            self.binds = list(binds) + ALWAYS_BIND
             self.env_vars = env_vars or get_all_envs()
 
         def make_command(self, cmd):

--- a/repos/system_upgrade/el7toel8/libraries/rhsm.py
+++ b/repos/system_upgrade/el7toel8/libraries/rhsm.py
@@ -81,7 +81,7 @@ def _handle_rhsm_exceptions(hint=None):
 
 def skip_rhsm():
     """Check whether we should skip RHSM related code."""
-    return os.getenv('LEAPP_DEVEL_SKIP_RHSM', '0') == '1'
+    return os.getenv('LEAPP_NO_RHSM', '0') == '1'
 
 
 def with_rhsm(f):


### PR DESCRIPTION
The development variable `LEAPP_DEVEL_SKIP_RHSM` is being deprecated and replaced with `LEAPP_NO_RHSM`, which is going to be officially supported.
At the framework level, setting `LEAPP_DEVEL_SKIP_RHSM` to 1 also sets `LEAPP_NO_RHSM` to 1. (This is intentional not to break existing tests and scripts.) Therefore, it makes sense to only check for the latter one in tests.