### PR TITLE
read_or_fetch: Add stream support

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/peseventsscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/peseventsscanner/libraries/peseventsscanner.py
@@ -137,7 +137,7 @@ def get_events(pes_json_directory, pes_json_filename):
     """
     try:
         return parse_pes_events(
-            fetch.read_or_fetch(pes_json_filename, directory=pes_json_directory, allow_empty=True))
+            fetch.read_or_fetch(pes_json_filename, directory=pes_json_directory, allow_empty=True, stream=True))
     except (ValueError, KeyError):
         title = 'Missing/Invalid PES data file ({}/{})'.format(pes_json_directory, pes_json_filename)
         summary = 'Read documentation at: https://access.redhat.com/articles/3664871 for more information ' \
@@ -170,13 +170,13 @@ def filter_events_by_releases(events, releases):
     return [e for e in events if e.to_release in releases]
 
 
-def parse_pes_events(json_data):
+def parse_pes_events(json_stream):
     """
     Parse JSON data returning PES events
 
     :return: List of Event tuples, where each event contains event type and input/output pkgs
     """
-    data = json.loads(json_data)
+    data = json.load(json_stream)
     if not isinstance(data, dict) or not data.get('packageinfo'):
         raise ValueError('Found PES data with invalid structure')
 

--- a/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/libraries/restrictedpcisscanner.py
+++ b/repos/system_upgrade/el7toel8/actors/restrictedpcisscanner/libraries/restrictedpcisscanner.py
@@ -36,6 +36,7 @@ def _raise_error(msg, details=None):
 
     raise StopActorExecutionError(msg, details=details)
 
+
 def _check_data(dev):
     """
     Raise the StopActorExecutionError when data for the source or target system
@@ -84,7 +85,7 @@ def _get_the_list(dev, prefix):
             api.current_logger().warning('Unknown field in restricted PCI data: {}'.format())
 
     result.sort()
-    return result 
+    return result
 
 
 def get_restricted_devices(filename):
@@ -97,8 +98,8 @@ def get_restricted_devices(filename):
     process the data now to make another work with it more friendly.
     """
     try:
-        json_data = fetch.read_or_fetch(UNSUPPORTED_DRIVER_NAMES_FILE)
-        data = json.loads(json_data, encoding='utf-8')
+        json_data = fetch.read_or_fetch(UNSUPPORTED_DRIVER_NAMES_FILE, stream=True)
+        data = json.load(json_data)
     except (JSONDecodeError, UnicodeDecodeError):
         _raise_error(
             'The required leapp data has invalid JSON format and cannot be decoded.'


### PR DESCRIPTION
This patch adds stream support for read_or_fetch to simplify the
handling of the JSON data returned by read_or_fetch. This way json.load
can take care of the conversion from bytes for us and we do not have to
take of this in the code. Especially because of the differences between
Python 2 and Python 3 code.

Signed-off-by: Vinzenz Feenstra <vfeenstr@redhat.com>